### PR TITLE
Add metrics section and new CTA buttons

### DIFF
--- a/src/app/(home)/page.tsx
+++ b/src/app/(home)/page.tsx
@@ -1,21 +1,19 @@
 import {
   FAQ,
-  Featured,
   FinancialFuture,
-  FinancilaFreedom,
   HeroSection,
   // IntroSection,
   JoinSection,
   OffersSection,
+  StatsSection,
 } from '@/components';
 
 export default function Home() {
   return (
     <main>
       <HeroSection />
-      <Featured />
+      <StatsSection />
       <OffersSection />
-      <FinancilaFreedom />
       <FinancialFuture />
       {/* <IntroSection /> */}
       <JoinSection />

--- a/src/components/Common/GetStartedButton/index.tsx
+++ b/src/components/Common/GetStartedButton/index.tsx
@@ -1,7 +1,13 @@
 import Link from 'next/link';
 import { LinkTo } from './styles';
 
-const GetStartedButton = ({ padding }: { padding: string }) => {
+const GetStartedButton = ({
+  padding,
+  label = 'Get Started',
+}: {
+  padding: string;
+  label?: string;
+}) => {
   return (
     <LinkTo
       style={{
@@ -9,7 +15,7 @@ const GetStartedButton = ({ padding }: { padding: string }) => {
       }}
       href="/"
     >
-      Get Started
+      {label}
     </LinkTo>
   );
 };

--- a/src/components/UI/FAQ/index.tsx
+++ b/src/components/UI/FAQ/index.tsx
@@ -12,6 +12,7 @@ import {
 import Image from 'next/image';
 import ic_chevron_down from '../../../../public/svgs/ic_chevron_down.svg';
 import { MaskText } from '@/components';
+import GetStartedButton from '@/components/Common/GetStartedButton';
 import { useIsMobile } from '../../../../libs/useIsMobile';
 import {
   animate,
@@ -71,6 +72,7 @@ const FAQ = () => {
             </AccordionItem>
           ))}
         </Accordion>
+        <GetStartedButton padding="1rem 2rem" label="Join the beta" />
       </Inner>
     </Wrapper>
   );

--- a/src/components/UI/FinancialFuture/index.tsx
+++ b/src/components/UI/FinancialFuture/index.tsx
@@ -24,6 +24,7 @@ import {
   mobileParagraphPhrase,
   stats,
 } from './constants';
+import GetStartedButton from '@/components/Common/GetStartedButton';
 
 const FinancialFuture = () => {
   const isMobile = useIsMobile();
@@ -65,6 +66,7 @@ const FinancialFuture = () => {
             </Stat>
           ))}
         </Stats>
+        <GetStartedButton padding="1rem 2rem" label="Join the beta" />
       </Inner>
       {/* <Banner>
         {isMobile ? (

--- a/src/components/UI/Header/index.tsx
+++ b/src/components/UI/Header/index.tsx
@@ -51,7 +51,7 @@ const Header = () => {
         </Nav>
         <CallToActions className={isOpen ? 'active' : ''}>
           <AnimatedLink title="Login" />
-          <GetStartedButton padding="0.5rem 0.75rem" />
+          <GetStartedButton padding="0.5rem 0.75rem" label="Join the beta" />
         </CallToActions>
       </Inner>
     </Wrapper>

--- a/src/components/UI/Header/styles.ts
+++ b/src/components/UI/Header/styles.ts
@@ -3,6 +3,10 @@ import Link from 'next/link';
 import { styled } from 'styled-components';
 
 export const Wrapper = styled.section`
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  background: var(--Background);
   padding: 1rem 0;
   border-bottom: 0.5px solid #3d3d3d;
 

--- a/src/components/UI/HeroSection/index.tsx
+++ b/src/components/UI/HeroSection/index.tsx
@@ -34,7 +34,7 @@ const HeroSection = () => {
             </>
           )}
         </HeroTextContainer>
-        <GetStartedButton padding="1rem 2rem" />
+        <GetStartedButton padding="1rem 2rem" label="Join the beta" />
       </Inner>
     </Wrapper>
   );

--- a/src/components/UI/JoinSection/index.tsx
+++ b/src/components/UI/JoinSection/index.tsx
@@ -18,6 +18,7 @@ import ic_arrow_left from '../../../../public/svgs/ic_arrow_left.svg';
 import ic_arrow_right from '../../../../public/svgs/ic_arrow_right.svg';
 import Image from 'next/image';
 import { MaskText } from '@/components';
+import GetStartedButton from '@/components/Common/GetStartedButton';
 import { useIsMobile } from '../../../../libs/useIsMobile';
 import { Props, desktopHeaderPhrase, testimonials } from './constants';
 
@@ -72,6 +73,7 @@ const JoinSection = () => {
             <Image src={ic_arrow_right} alt="arrow_right" />
           </Next>
         </PaginationButtonContainer>
+        <GetStartedButton padding="1rem 2rem" label="Join the beta" />
       </Inner>
     </Wrapper>
   );

--- a/src/components/UI/OffersSection/index.tsx
+++ b/src/components/UI/OffersSection/index.tsx
@@ -10,6 +10,7 @@ import {
   TextCtn,
 } from './styles';
 import MaskText from '@/components/Common/MaskText';
+import GetStartedButton from '@/components/Common/GetStartedButton';
 import { useIsMobile } from '../../../../libs/useIsMobile';
 import {
   desktopHeaderPhrases,
@@ -58,6 +59,7 @@ const OffersSection = () => {
             </OfferCard>
           ))}
         </Offers>
+        <GetStartedButton padding="1rem 2rem" label="Join the beta" />
       </Inner>
     </Wrapper>
   );

--- a/src/components/UI/StatsSection/constants.ts
+++ b/src/components/UI/StatsSection/constants.ts
@@ -1,0 +1,6 @@
+export const stats = [
+  { number: '10x', subtitle: 'faster prototyping' },
+  { number: '€50k', subtitle: 'cost savings' },
+  { number: '83%', subtitle: 'teams iterate faster' },
+  { number: '15min', subtitle: 'to first prototype' },
+];

--- a/src/components/UI/StatsSection/index.tsx
+++ b/src/components/UI/StatsSection/index.tsx
@@ -1,0 +1,25 @@
+'use client';
+import { Wrapper, Inner, Stats, Stat } from './styles';
+import { stats } from './constants';
+import MaskText from '@/components/Common/MaskText';
+import GetStartedButton from '@/components/Common/GetStartedButton';
+
+const StatsSection = () => {
+  return (
+    <Wrapper>
+      <Inner>
+        <Stats>
+          {stats.map((stat, i) => (
+            <Stat key={i}>
+              <MaskText phrases={[stat.number]} tag="h1" />
+              <MaskText phrases={[stat.subtitle]} tag="p" />
+            </Stat>
+          ))}
+        </Stats>
+        <GetStartedButton padding="1rem 2rem" label="Join the beta" />
+      </Inner>
+    </Wrapper>
+  );
+};
+
+export default StatsSection;

--- a/src/components/UI/StatsSection/styles.ts
+++ b/src/components/UI/StatsSection/styles.ts
@@ -1,0 +1,48 @@
+'use client';
+import { styled } from 'styled-components';
+
+export const Wrapper = styled.section`
+  padding-top: 6rem;
+`;
+
+export const Inner = styled.div`
+  width: 90%;
+  max-width: 1440px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+export const Stats = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  margin-bottom: 2rem;
+
+  @media (max-width: 768px) {
+    flex-direction: column;
+    gap: 2rem;
+  }
+`;
+
+export const Stat = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 0.5rem;
+
+  h1 {
+    font-size: 3rem;
+    font-weight: 600;
+  }
+
+  p {
+    color: var(--link-color);
+    font-size: 1rem;
+    font-weight: 500;
+    text-transform: uppercase;
+  }
+`;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,9 +1,8 @@
 export { default as Header } from './UI/Header';
 export { default as GetStartedButton } from './Common/GetStartedButton';
 export { default as HeroSection } from './UI/HeroSection';
-export { default as Featured } from './UI/Featured';
+export { default as StatsSection } from './UI/StatsSection';
 export { default as OffersSection } from './UI/OffersSection';
-export { default as FinancilaFreedom } from './UI/FinancialFreedom';
 export { default as FinancialFuture } from './UI/FinancialFuture';
 export { default as IntroSection } from './UI/IntroSection';
 export { default as JoinSection } from './UI/JoinSection';


### PR DESCRIPTION
## Summary
- add new StatsSection to highlight metrics
- remove Featured and Vision sections from home
- change all CTAs to say "Join the beta"
- make header sticky and include beta CTA

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842a8641de48328a80a1b11b855db2c